### PR TITLE
avoid a module conflict

### DIFF
--- a/src/FeatureCollection/FeatureCollection.js
+++ b/src/FeatureCollection/FeatureCollection.js
@@ -1,7 +1,9 @@
 import L from 'leaflet';
 
 import { arcgisToGeoJSON } from 'arcgis-to-geojson-utils';
-import { classBreaksRenderer, uniqueValueRenderer, simpleRenderer } from 'esri-leaflet-renderers';
+import { classBreaksRenderer } from 'esri-leaflet-renderers/src/Renderers/ClassBreaksRenderer';
+import { uniqueValueRenderer } from 'esri-leaflet-renderers/src/Renderers/UniqueValueRenderer';
+import { simpleRenderer } from 'esri-leaflet-renderers/src/Renderers/SimpleRenderer';
 
 export var FeatureCollection = L.GeoJSON.extend({
   options: {


### PR DESCRIPTION
bug fix #57 

This PR change the source pass of renderer modules to avoid conflict the different versions of `FeatureLayerHook.js`
