### PR TITLE
bump to heatmap 2.0.0 final and add support for custom vector tiles

### DIFF
--- a/examples/two-in-one.html
+++ b/examples/two-in-one.html
@@ -5,29 +5,35 @@
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
     <!-- Load Leaflet from CDN-->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.1/leaflet.css" />
-    <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.1/leaflet-src.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet-src.js"></script>
 
     <!-- Load Leaflet Label from GitHub -->
     <script src="https://leaflet.github.io/Leaflet.label/leaflet.label.js"></script>
 
     <!-- Load Esri Leaflet from CDN -->
-    <script src="https://cdn.jsdelivr.net/leaflet.esri/2.0.0/esri-leaflet.js"></script>
+    <script src="https://unpkg.com/esri-leaflet@2.0.8"></script>
 
-	<!-- Load Leaflet Heat from CDN -->
-	<script src="https://rawgit.com/Leaflet/Leaflet.heat/gh-pages/dist/leaflet-heat.js"></script>
+    <!-- Load Leaflet Heat from CDN -->
+    <script src="https://rawgit.com/Leaflet/Leaflet.heat/gh-pages/dist/leaflet-heat.js"></script>
 
-	<!-- Load Heatmap Feature Layer from CDN -->
-	<script src="https://cdn.jsdelivr.net/leaflet.esri.heatmap-feature-layer/2.0.0-beta.1/esri-leaflet-heatmap-feature-layer.js"></script>
+    <!-- Load Heatmap Feature Layer from CDN -->
+    <script src="https://unpkg.com/esri-leaflet-heatmap@2.0.0"></script>
+
+    <!-- Load Esri Leaflet Vector Tile from CDN -->
+    <script src="https://unpkg.com/esri-leaflet-vector@1.0.6"></script>
 
     <!-- Load Esri Leaflet Renderers from CDN -->
-    <script src="//cdn.jsdelivr.net/leaflet.esri.renderers/2.0.3/esri-leaflet-renderers.js"></script>
+    <script src="https://unpkg.com/esri-leaflet-renderers@2.0.4"></script>
 
     <!-- Load Vector Icon from GitHub -->
     <script src="https://muxlab.github.io/Leaflet.VectorIcon/L.VectorIcon.js"></script>
 
+    <!-- Load Leaflet Omnivore from CDN -->
+    <script src='//api.tiles.mapbox.com/mapbox.js/plugins/leaflet-omnivore/v0.3.1/leaflet-omnivore.min.js'></script>
+
     <!-- Load L.esri.WebMap -->
-	<script src="../dist/esri-leaflet-webmap-debug.js"></script>
+    <script src="dist/esri-leaflet-webmap-debug.js"></script>
 
   <style>
     body { margin:0; padding:0; }

--- a/index.html
+++ b/index.html
@@ -4,33 +4,33 @@
   <title>L.esri.WebMap Demo</title>
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
-  <!-- Load Leaflet from CDN-->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.3/leaflet.css" />
-  <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.3/leaflet-src.js"></script>
+    <!-- Load Leaflet from CDN-->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet-src.js"></script>
 
-  <!-- Load Esri Leaflet from CDN -->
-  <script src="https://cdn.jsdelivr.net/leaflet.esri/2.0.3/esri-leaflet.js"></script>
+    <!-- Load Esri Leaflet from CDN -->
+    <script src="https://unpkg.com/esri-leaflet@2.0.8"></script>
 
-	<!-- Load Leaflet Heat from CDN -->
-	<script src="https://rawgit.com/Leaflet/Leaflet.heat/gh-pages/dist/leaflet-heat.js"></script>
+    <!-- Load Leaflet Heat from CDN -->
+    <script src="https://rawgit.com/Leaflet/Leaflet.heat/gh-pages/dist/leaflet-heat.js"></script>
 
-	<!-- Load Heatmap Feature Layer from CDN -->
-	<script src="https://cdn.jsdelivr.net/leaflet.esri.heatmap-feature-layer/2.0.0-beta.1/esri-leaflet-heatmap-feature-layer.js"></script>
+    <!-- Load Heatmap Feature Layer from CDN -->
+    <script src="https://unpkg.com/esri-leaflet-heatmap@2.0.0"></script>
 
-  <!-- Load Esri Leaflet Vector Tile from CDN -->
-  <script src="//unpkg.com/esri-leaflet-vector@1.0.2"></script>
+    <!-- Load Esri Leaflet Vector Tile from CDN -->
+    <script src="https://unpkg.com/esri-leaflet-vector@1.0.6"></script>
 
-  <!-- Load Esri Leaflet Renderers from CDN -->
-  <script src="//cdn.jsdelivr.net/leaflet.esri.renderers/2.0.3/esri-leaflet-renderers.js"></script>
+    <!-- Load Esri Leaflet Renderers from CDN -->
+    <script src="https://unpkg.com/esri-leaflet-renderers@2.0.4"></script>
 
-  <!-- Load Vector Icon from GitHub -->
-  <script src="https://muxlab.github.io/Leaflet.VectorIcon/L.VectorIcon.js"></script>
+    <!-- Load Vector Icon from GitHub -->
+    <script src="https://muxlab.github.io/Leaflet.VectorIcon/L.VectorIcon.js"></script>
 
-  <!-- Load Leaflet Omnivore from CDN -->
-  <script src='//api.tiles.mapbox.com/mapbox.js/plugins/leaflet-omnivore/v0.3.1/leaflet-omnivore.min.js'></script>
+    <!-- Load Leaflet Omnivore from CDN -->
+    <script src='//api.tiles.mapbox.com/mapbox.js/plugins/leaflet-omnivore/v0.3.1/leaflet-omnivore.min.js'></script>
 
-	<!-- Load L.esri.WebMap -->
-	<script src="dist/esri-leaflet-webmap-debug.js"></script>
+    <!-- Load L.esri.WebMap -->
+    <script src="dist/esri-leaflet-webmap-debug.js"></script>
 
   <style>
     body { margin:0; padding:0; }

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
   "dependencies": {
     "arcgis-to-geojson-utils": "^1.0.1",
     "esri-leaflet": "^2.0.0",
-    "esri-leaflet-heatmap-feature-layer": "^2.0.0-beta.1",
+    "esri-leaflet-heatmap": "^2.0.0",
     "esri-leaflet-renderers": "^2.0.4",
-    "esri-leaflet-vector": "^1.0.2",
-    "leaflet": "^1.0.0-rc.1",
+    "esri-leaflet-vector": "^1.0.4",
+    "leaflet": "^1.0.0",
     "leaflet-omnivore": "^0.3.2",
     "leaflet-vectoricon": "^0.1.0",
     "leaflet.heat": "^0.1.3"

--- a/src/OperationalLayer.js
+++ b/src/OperationalLayer.js
@@ -98,7 +98,7 @@ export function _generateEsriLayer (layer, layers, map, params, paneName) {
           gradient[(Math.round(stop.ratio * 100) / 100 + 6) / 7] = 'rgb(' + stop.color[0] + ',' + stop.color[1] + ',' + stop.color[2] + ')';
         });
 
-        lyr = L.esri.Heat.heatmapFeatureLayer({ // Esri Leaflet 2.0
+        lyr = L.esri.Heat.featureLayer({ // Esri Leaflet 2.0
         // lyr = L.esri.heatmapFeatureLayer({ // Esri Leaflet 1.0
           url: layer.url,
           token: params.token || null,
@@ -381,8 +381,9 @@ export function _generateEsriLayer (layer, layers, map, params, paneName) {
     if (keys[layer.title]) {
       lyr = L.esri.Vector.basemap(keys[layer.title]);
     } else {
-      console.error('Unsupported Vector Tile Layer: ', layer);
-      lyr = L.featureGroup([]);
+      // console.error('Unsupported Vector Tile Layer: ', layer);
+      // lyr = L.featureGroup([]);
+      lyr = L.esri.Vector.layer(layer.itemId);
     }
 
     layers.push({ type: 'VTL', title: layer.title || layer.id || '', layer: lyr });


### PR DESCRIPTION
* bumped L.esri.Heatmap to `2.0.0` final
* bumped to L.esri.Vector `1.0.4` so that we can load custom vector tile layers

ex: [`dbdb160aacec417aa2b11cd6cc77b1dc`](http://edn.maps.arcgis.com/home/webmap/viewer.html?webmap=dbdb160aacec417aa2b11cd6cc77b1dc)

i hardly tested these changes, so feel free to examine closely before merging 🍟 